### PR TITLE
Update Puget version in plugin

### DIFF
--- a/src/whidbey/plugin.clj
+++ b/src/whidbey/plugin.clj
@@ -7,7 +7,7 @@
   [renderer]
   (when renderer
     `{:dependencies
-      [[mvxcvi/puget "0.5.1"]
+      [[mvxcvi/puget "0.5.2"]
        [mvxcvi/whidbey "RELEASE"]]
 
       :repl-options


### PR DESCRIPTION
0.5.1 is broken by Fipp's breaking removal of `defprinter`
