### PR TITLE
Better plugin injection

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,12 +28,12 @@ main motivation of this project), you can add the following in your `user`,
 :plugins [[mvxcvi/whidbey "0.5.1"]]
 
 ; customize printing options:
-:puget-options {:width 180
-                :map-delimiter ""
-                :print-meta true
-                :color-scheme {:delimiter [:blue]
-                               :tag [:bold :red]
-                               ...}}
+:whidbey {:width 180
+          :map-delimiter ""
+          :print-meta true
+          :color-scheme {:delimiter [:blue]
+                         :tag [:bold :red]
+                         ...}}
 ```
 
 See the Puget
@@ -42,8 +42,20 @@ var for the available configuration.
 
 ### Troubleshooting
 
-This may conflict with existing REPL customizations, so if necessary you can add
-the [profile configuration](src/whidbey/plugin.clj) yourself.
+Sometimes, there are types which Puget has trouble rendering. These can be
+excluded from pretty-printing by adding their symbol to the `:exclude-types` set
+in the options. These types will be printed with Puget's 'unknown type'
+rendering. If you want to use these types' `print-method` instead, set the
+`:print-fallback` option to `:print`:
+
+```clojure
+:whidbey {:print-fallback :print
+          :exclude-types #{datomic.db.DB ...}
+          ...}
+```
+
+Whidbey may also conflict with existing REPL customizations, so if necessary you
+can add the [profile configuration](src/whidbey/plugin.clj) yourself.
 
 If you experience errors, you can check how the profiles are being merged using
 the lein-pprint or [lein-cprint](https://github.com/greglook/lein-cprint)

--- a/project.clj
+++ b/project.clj
@@ -7,4 +7,5 @@
   :dependencies [[mvxcvi/puget "0.7.1"]
                  [org.clojure/tools.nrepl "0.2.7"]]
 
-  :profiles {:dev {:dependencies [[org.clojure/clojure "1.6.0"]]}})
+  :profiles {:dev {:dependencies [[leiningen-core "2.4.2"]
+                                  [org.clojure/clojure "1.6.0"]]}})

--- a/project.clj
+++ b/project.clj
@@ -4,8 +4,7 @@
   :license {:name "Public Domain"
             :url "http://unlicense.org/"}
 
-  :dependencies [[mvxcvi/puget "0.7.1"]
-                 [org.clojure/tools.nrepl "0.2.7"]]
+  :deploy-branches ["master"]
+  :eval-in-leiningen true
 
-  :profiles {:dev {:dependencies [[leiningen-core "2.4.2"]
-                                  [org.clojure/clojure "1.6.0"]]}})
+  :dependencies [[mvxcvi/puget "0.8.0-SNAPSHOT"]])

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject mvxcvi/whidbey "0.5.1"
+(defproject mvxcvi/whidbey "0.6.0-SNAPSHOT"
   :description "nREPL middleware to allow arbitrary value rendering."
   :url "https://github.com/greglook/whidbey"
   :license {:name "Public Domain"

--- a/src/clojure/tools/nrepl/middleware/render_values.clj
+++ b/src/clojure/tools/nrepl/middleware/render_values.clj
@@ -3,10 +3,7 @@
     [clojure.string :as str]
     (clojure.tools.nrepl
       [middleware :as middleware]
-      transport)
-    (clojure.tools.nrepl.middleware
-      interruptible-eval
-      pr-values))
+      transport))
   (:import
     clojure.tools.nrepl.transport.Transport))
 
@@ -56,16 +53,3 @@
   {:requires #{}
    :expects #{"eval"}
    :handles {}})
-
-
-; Here's where things get ugly. We need to prevent the native `pr-values`
-; middleware from loading, but the `interruptible-eval` middleware explicitly
-; requires it.
-(alter-meta!
-  #'clojure.tools.nrepl.middleware.interruptible-eval/interruptible-eval
-  update-in [:clojure.tools.nrepl.middleware/descriptor :requires]
-  disj #'clojure.tools.nrepl.middleware.pr-values/pr-values)
-
-; Make pr-values a no-op to prevent re-inclusion from messing things up.
-(alter-var-root #'clojure.tools.nrepl.middleware.pr-values/pr-values
-                (constantly identity))

--- a/src/whidbey/plugin.clj
+++ b/src/whidbey/plugin.clj
@@ -20,7 +20,7 @@
 
 (defn middleware
   [project]
-  (let [options (:puget-options project)
+  (let [options (:whidbey project (:puget-options project))
         included (:included-profiles (meta project))]
     (if (some #{::profile} included)
       project

--- a/src/whidbey/plugin.clj
+++ b/src/whidbey/plugin.clj
@@ -5,9 +5,25 @@
     [leiningen.core.project :as project]))
 
 
-;; These versions are spliced into the project dependencies.
-(def puget-version "0.8.0-SNAPSHOT")
-(def whidbey-version "0.6.0-SNAPSHOT")
+(defn- find-plugin-version
+  "Looks up the plugins in the project map and tries to find the version
+  specified for the given symbol. Returns nil if none matches."
+  [project plugin]
+  (try
+    (some (fn [[p v]] (when (= p plugin) v))
+          (:plugins project))
+    (catch Exception e
+      nil)))
+
+
+(defn- plugin-dependency
+  "Looks up the version for the given plugin, or sets it to `\"RELEASE\"`.
+  Returns a dependency vector entry."
+  [project plugin]
+  (vector
+   plugin
+   (or (find-plugin-version project plugin)
+       "RELEASE")))
 
 
 (defn- add-dependencies
@@ -68,8 +84,7 @@
       (some (set target-profiles) active-profiles)
         (-> project
             (add-dependencies
-              `[mvxcvi/puget ~puget-version]
-              `[mvxcvi/whidbey ~whidbey-version])
+              (plugin-dependency project 'mvxcvi/whidbey))
             (add-repl-init
               `(require 'whidbey.repl)
               `(whidbey.repl/init! ~options))

--- a/src/whidbey/plugin.clj
+++ b/src/whidbey/plugin.clj
@@ -6,8 +6,8 @@
 
 
 ;; These versions are spliced into the project dependencies.
-(def puget-version "0.7.1")
-(def whidbey-version "0.5.1")
+(def puget-version "0.8.0-SNAPSHOT")
+(def whidbey-version "0.6.0-SNAPSHOT")
 
 
 (defn- add-dependencies

--- a/src/whidbey/plugin.clj
+++ b/src/whidbey/plugin.clj
@@ -5,6 +5,7 @@
 
 (defn whidbey-profile
   [options]
+  ; TODO: how to keep dependencies out of POM files?
   `{:dependencies [[mvxcvi/puget "0.7.1"]
                    [mvxcvi/whidbey "0.5.1"]]
 

--- a/src/whidbey/plugin.clj
+++ b/src/whidbey/plugin.clj
@@ -1,30 +1,76 @@
 (ns whidbey.plugin
+  "This namespace runs inside of Leiningen and rewrites the project map to
+  include the customizations provided by Whidbey."
   (:require
     [leiningen.core.project :as project]))
 
 
-(defn whidbey-profile
-  [options]
-  ; TODO: how to keep dependencies out of POM files?
-  `{:dependencies [[mvxcvi/puget "0.7.1"]
-                   [mvxcvi/whidbey "0.5.1"]]
+;; These versions are spliced into the project dependencies.
+(def puget-version "0.7.1")
+(def whidbey-version "0.5.1")
 
-    :injections [(do (require 'whidbey.render)
-                     (alter-var-root
-                       #'whidbey.render/puget-options
-                       merge
-                       ~options))]
 
-    :repl-options {:nrepl-middleware [clojure.tools.nrepl.middleware.render-values/render-values]
-                   :nrepl-context {:interactive-eval {:renderer whidbey.render/render-str}}}})
+(defn- add-dependencies
+  "Adds some dependencies to the end of the current vector."
+  [project & deps]
+  (update-in project [:dependencies] concat deps))
+
+
+(defn- add-repl-init
+  "Adds the given repl initialization forms to the `:init` key in
+  `:repl-options`. Any existing initialization will happen before the
+  form is executed."
+  [project & forms]
+  (update-in project
+             [:repl-options :init]
+             (fn [current]
+               (if current
+                 `(do ~current ~@forms)
+                 `(do ~@forms)))))
+
+
+(defn- add-nrepl-middleware
+  "Adds the middleware identified by the given symbol to the *front* of the
+  current nrepl-middleware list in the project map."
+  [project sym]
+  (update-in project
+             [:repl-options :nrepl-middleware]
+             #(into [sym] %)))
+
+
+(defn- set-interactive-eval-renderer
+  "Sets the nrepl renderer for the interactive-eval context to the function
+  named by the given symbol."
+  [project sym]
+  (assoc-in project
+            [:repl-options :nrepl-context :interactive-eval :renderer]
+            sym))
 
 
 (defn middleware
+  "Rewrites the project to include Whidbey's customizations when the `:repl`
+  profile is active."
   [project]
-  (let [options (:whidbey project (:puget-options project))
-        included (:included-profiles (meta project))]
-    (if (some #{::profile} included)
+  (cond
+    ; Idempotent if the project has already been updated.
+    (::included (meta project))
       project
-      (-> project
-          (project/add-profiles {::profile (whidbey-profile options)})
-          (project/merge-profiles [::profile])))))
+
+    ; Only modify the project for repl invocations.
+    (some #{:repl} (:included-profiles (meta project)))
+      (let [options (:whidbey project (:puget-options project))]
+        (-> project
+            (add-dependencies
+              `[mvxcvi/puget ~puget-version]
+              `[mvxcvi/whidbey ~whidbey-version])
+            (add-repl-init
+              `(require 'whidbey.repl)
+              `(whidbey.repl/init! ~options))
+            (add-nrepl-middleware
+              'clojure.tools.nrepl.middleware.render-values/render-values)
+            (set-interactive-eval-renderer
+              'whidbey.render/render-str)
+            (vary-meta assoc ::included true)))
+
+    ; Otherwise, return project unchanged.
+    :else project))

--- a/src/whidbey/render.clj
+++ b/src/whidbey/render.clj
@@ -3,13 +3,20 @@
     [puget.printer :as puget]))
 
 
-(def puget-options
+(def options
   "Currently configured Puget options."
-  {:print-color true})
+  {:print-color true
+   :exclude-types #{'datomic.db.DB}})
+
+
+(defn update-options!
+  "Updates the current rendering options by merging in the supplied map."
+  [opts]
+  (alter-var-root #'options puget/merge-options opts))
 
 
 (defn render-str
   "Renders the given value to a display string by pretty-printing it using Puget
   and the configured options."
   [value]
-  (puget/pprint-str value puget-options))
+  (puget/pprint-str value options))

--- a/src/whidbey/repl.clj
+++ b/src/whidbey/repl.clj
@@ -1,22 +1,11 @@
 (ns whidbey.repl
   (:require
-    (clojure.tools.nrepl.middleware
-      [pr-values :refer [pr-values]]
-      [render-values :refer [render-values]])
-    [clojure.tools.nrepl.server :refer [default-handler]]
+    [clojure.tools.nrepl.middleware.pr-values :refer [pr-values]]
     [whidbey.render :as render]))
-
-
-(defn wrap-nrepl-handler!
-  "Alters the nrepl server handler by wrapping it with Whidbey's `render-values`
-  middleware and deactivating the default `pr-value`."
-  []
-  ;(alter-var-root #'default-handler #'render-values)
-  (alter-var-root #'pr-values (constantly identity)))
 
 
 (defn init!
   "Initializes the repl to use Whidbey's customizations."
   [options]
   (render/update-options! options)
-  (wrap-nrepl-handler!))
+  (alter-var-root #'pr-values (constantly identity)))

--- a/src/whidbey/repl.clj
+++ b/src/whidbey/repl.clj
@@ -1,0 +1,22 @@
+(ns whidbey.repl
+  (:require
+    (clojure.tools.nrepl.middleware
+      [pr-values :refer [pr-values]]
+      [render-values :refer [render-values]])
+    [clojure.tools.nrepl.server :refer [default-handler]]
+    [whidbey.render :as render]))
+
+
+(defn wrap-nrepl-handler!
+  "Alters the nrepl server handler by wrapping it with Whidbey's `render-values`
+  middleware and deactivating the default `pr-value`."
+  []
+  ;(alter-var-root #'default-handler #'render-values)
+  (alter-var-root #'pr-values (constantly identity)))
+
+
+(defn init!
+  "Initializes the repl to use Whidbey's customizations."
+  [options]
+  (render/update-options! options)
+  (wrap-nrepl-handler!))


### PR DESCRIPTION
@venantius I took a page or two out of Ultra's plugin loading code and improved a bunch of stuff about how Whidbey gets loaded. This should make Ultra's integration a lot simpler as well - let me know if you want me to make any of the helper functions in `whidbey.plugin` public for use there.

This also fixes a more serious issue which has been plaguing me for a little bit. Right now if you have Whidbey listed as a plugin in your `user`, `system`, or `dev` profiles, the injected dependencies show up in the `pom.xml` files generated by Leiningen. This means that deploying releases (say, to Clojars) generates jars that have listed dependencies against `mvxcvi/puget` and `mvxcvi/whidbey`! Oops. The fix here is to test whether the project map includes one of a set of _target profiles_, by default just `#{:repl}`.