### PR TITLE
Add support for nREPL 0.6.0

### DIFF
--- a/src/whidbey/plugin.clj
+++ b/src/whidbey/plugin.clj
@@ -18,17 +18,22 @@
 
 (defn- whidbey-profile
   "Constructs a profile map for enabling the repl hooks."
-  [version options]
-  (->
-    `{:dependencies [[mvxcvi/whidbey ~(or version "RELEASE")]]
-      ;; :init is run once when the server starts
-      ;; :custom-init is run on session creation
-      :repl-options {:init (do (require 'whidbey.repl)
-                               (whidbey.repl/init! ~options))
-                     :custom-init (whidbey.repl/update-print-fn!)
-                     ;; :printer is nrepl 0.5.x only
-                     :nrepl-context {:interactive-eval {:printer whidbey.repl/render-str}}}}
-    (vary-meta assoc :repl true)))
+  [project]
+  (let [version (find-plugin-version project 'mvxcvi/whidbey)
+        options (:whidbey project)
+        {:keys [init custom-init]} (:repl-options project)]
+    (-> `{:dependencies [[mvxcvi/whidbey ~(or version "RELEASE")]]
+          ;; :init is run once when the server starts
+          ;; :custom-init is run on session creation
+          ;; ^:replace to workaround https://github.com/technomancy/leiningen/issues/878
+          :repl-options {:init ^:replace (do ~init
+                                             (require 'whidbey.repl)
+                                             (whidbey.repl/init! ~options))
+                         :custom-init ^:replace (do ~custom-init
+                                                    (whidbey.repl/update-print-fn!))
+                         ;; :printer is nrepl 0.5.x only
+                         :nrepl-context {:interactive-eval {:printer whidbey.repl/render-str}}}}
+        (vary-meta assoc :repl true))))
 
 
 (defn repl-pprint
@@ -38,7 +43,5 @@
   [project]
   (if (:whidbey/repl (:profiles project))
     project
-    (let [options (:whidbey project)
-          version (find-plugin-version project 'mvxcvi/whidbey)
-          profile (whidbey-profile version options)]
+    (let [profile (whidbey-profile project)]
       (project/add-profiles project {:whidbey/repl profile}))))

--- a/src/whidbey/plugin.clj
+++ b/src/whidbey/plugin.clj
@@ -21,9 +21,13 @@
   [version options]
   (->
     `{:dependencies [[mvxcvi/whidbey ~(or version "RELEASE")]]
-      :repl-options {:nrepl-context {:interactive-eval {:printer whidbey.repl/render-str}}
-                     :init (do (require 'whidbey.repl)
-                               (whidbey.repl/init! ~options))}}
+      ;; :init is run once when the server starts
+      ;; :custom-init is run on session creation
+      :repl-options {:init (do (require 'whidbey.repl)
+                               (whidbey.repl/init! ~options))
+                     :custom-init (whidbey.repl/update-print-fn!)
+                     ;; :printer is nrepl 0.5.x only
+                     :nrepl-context {:interactive-eval {:printer whidbey.repl/render-str}}}}
     (vary-meta assoc :repl true)))
 
 

--- a/src/whidbey/repl.clj
+++ b/src/whidbey/repl.clj
@@ -51,6 +51,16 @@
     (assoc opts :print-handlers (print-handlers opts))))
 
 
+(defn render
+  "Renders the given value for display by pretty-printing it on the given writer
+  using Puget and the configured options."
+  ([value writer]
+   (render value writer nil))
+  ([value writer opts]
+   (binding [*out* writer]
+     (puget/pprint value (print-options opts)))))
+
+
 (defn render-str
   "Renders the given value to a display string by pretty-printing it using Puget
   and the configured options."
@@ -62,6 +72,14 @@
 
 
 ;; ## Initialization
+
+(defn update-print-fn!
+  "Updates nREPL's printing configuration to use Puget. nREPL 0.6.0+ only."
+  []
+  (some-> (find-ns 'nrepl.middleware.print)
+          (ns-resolve '*print-fn*)
+          (var-set render)))
+
 
 (defn update-options!
   "Updates the current rendering options by merging in the supplied map."


### PR DESCRIPTION
nREPL now has the `set!`-able dynamic var `nrepl.middleware.print/*print-fn*` so tools like Whidbey can set a session-wide default printer, but clients can still override this on a per-request basis by including the relevant option in the request.

To be able to `set!` this, we need to switch from using [`:init`](https://github.com/technomancy/leiningen/blob/master/src/leiningen/repl.clj#L241) to [`:custom-init`](https://github.com/trptcolin/reply/blob/master/src/clj/reply/eval_modes/nrepl.clj#L231-L233). The former is evaluated only once when the REPL server starts, but the latter is evaluated each time a new client session is created (with `set!`-able bindings in place).

I have left the `:nrepl-context` code in place so nREPL 0.5.x still works.

Additionally, because of technomancy/leiningen#878, there's a bit of a sharp edge around using `:init` or `:custom-init` – they aren't merged in the way you might expect. Instead splice any existing form into our init code and overwrite the existing configuration with `^:replace`.

Fixes #27.